### PR TITLE
Use rumiator into existing project

### DIFF
--- a/.claude/commands/rumiator-use-into-existing-project.md
+++ b/.claude/commands/rumiator-use-into-existing-project.md
@@ -1,0 +1,45 @@
+Integrate Rumiator into an existing project by analyzing current state and creating a retrospective product plan.
+
+Prerequisites:
+- Project must not already have .rumiator/ initialized
+
+## Language Configuration
+**IMPORTANT**: Before starting, determine the user's language:
+1. Check if `.rumiator/config.yml` exists and read the `language` field
+2. If not, read `.rumiator/config.yml.template` to get the `language` field
+3. **Use that language for ALL communication**
+
+## Steps
+
+1. Check if .rumiator/ exists. If yes, ask user if they want to backup and reinitialize
+2. Initialize Rumiator structure (same as /rumiator-init):
+   - Create directories: .rumiator/tasks/, docs/product/, docs/adr/, docs/features/, docs/iterations/, docs/devops/
+   - Copy .rumiator/config.yml.template to .rumiator/config.yml
+3. Analyze the project:
+   - Examine code structure, git history (last 30 commits), package.json/requirements.txt/etc
+   - Identify tech stack, main features, and project maturity
+   - Ask user to confirm findings:
+     * Project name (suggest from repo)
+     * Description/purpose
+     * Tech stack assessment
+     * Key features to document
+4. Launch project-manager agent to create:
+   - `docs/product/product-state.md`: Current vision, features list, tech stack, evolution from git history
+   - `docs/product/product-plan.md`: Vision, stakeholders, 3-5 iterations roadmap, risks, success criteria
+   - `docs/product/architecture.md`: Architecture overview with Mermaid diagram
+5. Update .rumiator/config.yml with project details
+6. Create initial draft tasks in .rumiator/tasks/ for first 2 iterations (status: "draft")
+7. Show summary of generated files with key findings
+8. Ask user to review the documentation and provide feedback:
+   - Is the product vision accurate?
+   - Any missing or incorrect features?
+   - Tech stack assessment correct?
+   - Iteration planning makes sense?
+9. If user requests changes, update the relevant documents and config
+10. Display success message and next steps:
+    - Run `/rumiator-status` to see project dashboard
+    - Review draft tasks in .rumiator/tasks/
+    - Run `/rumiator-create-tasks` to elaborate task details
+    - Run `/rumiator-analyze-business` to create functional specs
+
+Important: Be flexible and collaborative. User knows their project best - iterate on the documentation until they're satisfied.

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -12,17 +12,40 @@ Welcome! This guide will help you set up and start using Rumiator in 5 minutes.
 
 Rumiator is already installed in this directory! All agents and commands are ready to use.
 
-To use Rumiator in **another project**:
+### Option 1: Quick Setup with Bash Alias (Recommended)
 
-1. Copy the entire `.claude/` directory to your project
-2. Copy the `.rumiator/` directory to your project
-3. You're done!
+Add this alias to your `~/.bashrc` or `~/.zshrc`:
+
+```bash
+# Replace /path/to/rumiator with the actual path where you cloned this repo
+alias init-rumiator='mkdir -p .claude && mkdir -p .rumiator && cp -rf /path/to/rumiator/.claude/* .claude/ && cp -rf /path/to/rumiator/.rumiator/* .rumiator/'
+```
+
+Then, to install Rumiator in any project:
+
+```bash
+cd /path/to/your/project
+init-rumiator
+```
+
+### Option 2: Manual Installation
 
 ```bash
 # From this directory:
 cp -r .claude /path/to/your/project/
 cp -r .rumiator /path/to/your/project/
 ```
+
+### Option 3: For Existing Projects with Code
+
+If your project already has code and you want to generate documentation based on the current state:
+
+1. First install Rumiator (using Option 1 or 2)
+2. In Claude Code, run:
+   ```
+   /rumiator-use-into-existing-project
+   ```
+3. Answer the questions and review generated documentation
 
 ## Your First Project (5 minutes)
 
@@ -214,7 +237,7 @@ Absolutely! All generated docs are meant to be reviewed and refined by you.
 Just edit the document or tell the agent when it asks. You're in control.
 
 ### "Can I use this with existing projects?"
-Yes! Run `/rumiator-init` in your existing project. You can document existing features retroactively or use it only for new features.
+Yes! Use `/rumiator-use-into-existing-project` to analyze your codebase and generate documentation based on what you've already built. Or use `/rumiator-init` if you only want to use Rumiator for new features going forward.
 
 ---
 

--- a/QUICK-REFERENCE.md
+++ b/QUICK-REFERENCE.md
@@ -4,6 +4,7 @@ One-page cheat sheet for Rumiator commands and workflows.
 
 ## 🚀 Essential Commands
 
+### For New Projects
 ```bash
 /rumiator-init                    # Initialize project
 /rumiator-create-product          # Create product plan
@@ -12,6 +13,13 @@ One-page cheat sheet for Rumiator commands and workflows.
 /rumiator-analyze-tech all        # Create technical specs
 /rumiator-develop-next            # Auto-develop next task
 /rumiator-status                  # Show dashboard
+```
+
+### For Existing Projects
+```bash
+/rumiator-use-into-existing-project  # Analyze codebase & generate docs
+/rumiator-status                     # Show dashboard
+/rumiator-develop-next               # Continue development
 ```
 
 ## 📊 Task States Flow
@@ -49,7 +57,8 @@ draft → pending-business-analysis → pending-technical-analysis
 
 | Command | When to Use | What It Does |
 |---------|-------------|--------------|
-| `/rumiator-init` | Once, at start | Creates project structure |
+| `/rumiator-init` | Once, at start (new projects) | Creates project structure |
+| `/rumiator-use-into-existing-project` | Once, at start (existing projects) | Analyzes code & creates retrospective docs |
 | `/rumiator-create-product` | Once, at start | Generates product plan from idea |
 | `/rumiator-update-plan` | When scope changes | Updates product plan |
 | `/rumiator-create-tasks` | Start of iteration | Creates task list from plan |
@@ -165,6 +174,14 @@ blockers: []
 /rumiator-create-tasks
 /rumiator-analyze-business all
 /rumiator-analyze-tech all
+```
+
+### Integrating into Existing Project
+```bash
+/rumiator-use-into-existing-project
+# Review and refine generated docs
+/rumiator-status
+/rumiator-develop-next
 ```
 
 ### Daily Development

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Rumiator helps you build software projects systematically by combining specializ
 
 ## Quick Start
 
+### For New Projects
+
 ```bash
 # 1. Initialize your project
 /rumiator-init
@@ -25,6 +27,17 @@ Rumiator helps you build software projects systematically by combining specializ
 
 # 6. Monitor progress
 /rumiator-status
+```
+
+### For Existing Projects
+
+```bash
+# 1. Initialize and analyze existing codebase
+/rumiator-use-into-existing-project
+
+# 2. Review and refine generated documentation
+# 3. Continue with development workflow
+/rumiator-develop-next
 ```
 
 ## Features
@@ -52,6 +65,7 @@ Rumiator helps you build software projects systematically by combining specializ
 | Command | Purpose |
 |---------|---------|
 | `/rumiator-init` | Initialize project structure |
+| `/rumiator-use-into-existing-project` | Integrate Rumiator into existing project |
 | `/rumiator-create-product` | Create product plan from idea |
 | `/rumiator-update-plan` | Update product plan |
 | `/rumiator-create-tasks` | Generate tasks from plan |
@@ -140,6 +154,31 @@ Topics covered:
 - Best practices
 - Customization guide
 - FAQ
+
+## Installation
+
+### Quick Setup with Bash Alias
+
+Add this alias to your `~/.bashrc` or `~/.zshrc`:
+
+```bash
+# Replace /path/to/rumiator with the actual path where you cloned this repo
+alias init-rumiator='mkdir -p .claude && mkdir -p .rumiator && cp -rf /path/to/rumiator/.claude/* .claude/ && cp -rf /path/to/rumiator/.rumiator/* .rumiator/'
+```
+
+Then, in any project directory:
+
+```bash
+init-rumiator  # Copies all Rumiator files to current project
+```
+
+### Manual Installation
+
+```bash
+# From this repository directory:
+cp -r .claude /path/to/your/project/
+cp -r .rumiator /path/to/your/project/
+```
 
 ## Requirements
 


### PR DESCRIPTION
# Description

  Add support for integrating Rumiator into existing projects

  This PR introduces a new workflow that allows developers to adopt
  Rumiator in projects that already have existing code, along with
  improved installation methods.

# What's New

  1. New Command: `/rumiator-use-into-existing-project`

  A new slash command that performs retrospective analysis of existing
  codebases and generates comprehensive documentation based on what's
  already been built.

Updated docs, to explain how to use it.