### PR TITLE
fix: reorganize tasks by iteration to prevent conflicts (#9)

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -25,7 +25,7 @@ You are a Software Architect specialized in evaluating technical approach and ar
 
 ## Working Context
 - You work within the **Rumiator** framework
-- Tasks are in `.rumiator/tasks/` with business requirements already defined
+- Tasks are in `docs/iterations/iteration-XX/tasks/` (where XX is current iteration) with business requirements already defined
 - Technical specs go in `docs/features/[feature-name]/technical.md`
 - Overall architecture is in `docs/product/architecture.md`
 - ADRs are in `docs/adr/`
@@ -35,13 +35,14 @@ You are a Software Architect specialized in evaluating technical approach and ar
 **Input**: Task YAML with status `pending-technical-analysis` (includes summary, user_stories, acceptance_criteria)
 
 **Process**:
-1. Read task YAML to understand business requirements
-2. Read `docs/product/architecture.md` to understand current system architecture
-3. Read existing ADRs to understand architectural decisions
-4. Evaluate if this task requires an ADR:
+1. Read `.rumiator/config.yml` to get the current iteration number
+2. Read task YAML from `docs/iterations/iteration-XX/tasks/` to understand business requirements
+3. Read `docs/product/architecture.md` to understand current system architecture
+4. Read existing ADRs to understand architectural decisions
+5. Evaluate if this task requires an ADR:
    - **Create ADR if**: Major technology choice, significant architectural decision, or pattern change
    - **Ask user** to validate ADR before continuing
-5. Create `docs/features/[feature-name]/technical.md` following the simplified template:
+6. Create `docs/features/[feature-name]/technical.md` following the simplified template:
    - **Technology Stack**: Which technologies/frameworks to use
    - **Architecture Overview**: How feature fits into system (high-level diagram)
    - **Technical Considerations**:

--- a/.claude/agents/developer-backend.md
+++ b/.claude/agents/developer-backend.md
@@ -27,7 +27,7 @@ You are a Backend Developer specialized in building robust, scalable server-side
 
 ## Working Context
 - You work within the **Rumiator** framework
-- Task details are in `.rumiator/tasks/TASK-XXX.yml`
+- Task details are in `docs/iterations/iteration-XX/tasks/TASK-XXX.yml` (where XX is current iteration number)
 - Functional spec: `docs/features/[feature-name]/functional.md`
 - Technical spec: `docs/features/[feature-name]/technical.md`
 - Source code is in `src/` or as defined in project structure
@@ -36,9 +36,10 @@ You are a Backend Developer specialized in building robust, scalable server-side
 **Input**: Task with status `ready-for-development` (backend or fullstack)
 
 **Process**:
-1. Read task YAML, functional spec, and technical spec
-2. Review API contracts and data models in technical spec
-3. Implement the feature:
+1. Read `.rumiator/config.yml` to get current iteration number
+2. Read task YAML from `docs/iterations/iteration-XX/tasks/`, functional spec, and technical spec
+3. Review API contracts and data models in technical spec
+4. Implement the feature:
    - Create database migrations if schema changes needed
    - Implement data models/entities
    - Create repository/DAO layer for data access

--- a/.claude/agents/developer-frontend.md
+++ b/.claude/agents/developer-frontend.md
@@ -26,7 +26,7 @@ You are a Frontend Developer specialized in building modern, responsive user int
 
 ## Working Context
 - You work within the **Rumiator** framework
-- Task details are in `.rumiator/tasks/TASK-XXX.yml`
+- Task details are in `docs/iterations/iteration-XX/tasks/TASK-XXX.yml` (where XX is current iteration number)
 - Functional spec: `docs/features/[feature-name]/functional.md`
 - Technical spec: `docs/features/[feature-name]/technical.md`
 - Source code is in `src/` or as defined in project structure
@@ -35,10 +35,11 @@ You are a Frontend Developer specialized in building modern, responsive user int
 **Input**: Task with status `ready-for-development` (frontend or fullstack)
 
 **Process**:
-1. Read task YAML, functional spec, and technical spec
-2. Review acceptance criteria carefully
-3. Identify components, pages, and hooks needed
-4. Implement the feature:
+1. Read `.rumiator/config.yml` to get current iteration number
+2. Read task YAML from `docs/iterations/iteration-XX/tasks/`, functional spec, and technical spec
+3. Review acceptance criteria carefully
+4. Identify components, pages, and hooks needed
+5. Implement the feature:
    - Create components following atomic design principles
    - Implement state management (Context, Redux, Zustand, etc.)
    - Integrate with backend APIs

--- a/.claude/agents/devops.md
+++ b/.claude/agents/devops.md
@@ -27,7 +27,7 @@ You are a DevOps Engineer specialized in CI/CD, infrastructure, and deployment a
 
 ## Working Context
 - You work within the **Rumiator** framework
-- Task details are in `.rumiator/tasks/TASK-XXX.yml`
+- Task details are in `docs/iterations/iteration-XX/tasks/TASK-XXX.yml` (where XX is current iteration number)
 - Technical spec: `docs/features/[feature-name]/technical.md`
 - Architecture: `docs/product/architecture.md`
 - Check `.rumiator/config.yml` for deployment platform
@@ -36,9 +36,10 @@ You are a DevOps Engineer specialized in CI/CD, infrastructure, and deployment a
 **Input**: Task with status `ready-for-development` (devops-related)
 
 **Process**:
-1. Read task YAML, technical spec, and architecture doc
-2. Understand deployment requirements and constraints
-3. Implement the infrastructure/pipeline:
+1. Read `.rumiator/config.yml` to get current iteration number
+2. Read task YAML from `docs/iterations/iteration-XX/tasks/`, technical spec, and architecture doc
+3. Understand deployment requirements and constraints
+4. Implement the infrastructure/pipeline:
    - Create Dockerfiles for services
    - Set up CI/CD configuration (GitHub Actions, GitLab CI, etc.)
    - Define infrastructure as code

--- a/.claude/agents/functional-analyst.md
+++ b/.claude/agents/functional-analyst.md
@@ -24,7 +24,7 @@ You are a Business Analyst specialized in creating task definitions with clear b
 
 ## Working Context
 - You work within the **Rumiator** framework
-- Tasks are stored as YAML files in `.rumiator/tasks/`
+- Tasks are stored as YAML files in `docs/iterations/iteration-XX/tasks/` where XX is the current iteration number
 - You create tasks that will be analyzed by the architect agent for technical details
 - **Focus on WHAT and WHY, NOT HOW**
 
@@ -32,9 +32,10 @@ You are a Business Analyst specialized in creating task definitions with clear b
 **Input**: `docs/product/product-plan.md`
 
 **Process**:
-1. Read the product plan and identify all features for the current iteration
-2. For each feature, create:
-   - `.rumiator/tasks/TASK-XXX.yml` with the following information:
+1. Read `.rumiator/config.yml` to get the current iteration number
+2. Read the product plan and identify all features for the current iteration
+3. For each feature, create:
+   - `docs/iterations/iteration-XX/tasks/TASK-XXX.yml` (where XX is current iteration) with the following information:
      * **id**: TASK-XXX (sequential)
      * **type**: feature (or bug, architecture-review)
      * **title**: Clear, concise title
@@ -48,7 +49,7 @@ You are a Business Analyst specialized in creating task definitions with clear b
      * **created**: Current date (YYYY-MM-DD)
      * **updated**: Current date (YYYY-MM-DD)
    - `docs/features/[feature-name]/` directory
-3. Update `.rumiator/config.yml` to track the new tasks
+4. Update `.rumiator/config.yml` to track the new tasks if needed
 
 **CRITICAL**: Tasks should be created directly in status `pending-technical-analysis`.
 There is NO separate "business analysis" phase - all business requirements are captured during task creation.

--- a/.claude/agents/quality-assurance.md
+++ b/.claude/agents/quality-assurance.md
@@ -26,7 +26,7 @@ You are a QA Engineer specialized in ensuring software quality through testing a
 
 ## Working Context
 - You work within the **Rumiator** framework
-- Task details are in `.rumiator/tasks/TASK-XXX.yml`
+- Task details are in `docs/iterations/iteration-XX/tasks/TASK-XXX.yml` (where XX is current iteration number)
 - Functional spec: `docs/features/[feature-name]/functional.md`
 - Technical spec: `docs/features/[feature-name]/technical.md`
 
@@ -34,9 +34,10 @@ You are a QA Engineer specialized in ensuring software quality through testing a
 **Input**: Task with status `in-review` or `done` (pending QA validation)
 
 **Process**:
-1. Read task YAML, functional spec, and technical spec
-2. Review the acceptance criteria
-3. Verify implementation:
+1. Read `.rumiator/config.yml` to get current iteration number
+2. Read task YAML from `docs/iterations/iteration-XX/tasks/`, functional spec, and technical spec
+3. Review the acceptance criteria
+4. Verify implementation:
    - Check that all acceptance criteria are met
    - Test all user flows (main + alternative)
    - Test edge cases and error scenarios

--- a/.claude/commands/rumiator-analyze-business.md
+++ b/.claude/commands/rumiator-analyze-business.md
@@ -37,7 +37,7 @@ Usage:
 - /rumiator-analyze-business all - Analyze all tasks pending business analysis
 
 Prerequisites:
-- Tasks must exist in .rumiator/tasks/ with status "pending-business-analysis"
+- Tasks must exist in docs/iterations/iteration-XX/tasks/ with status "pending-business-analysis"
 
 ## Language Configuration
 **IMPORTANT**: Before starting, determine the user's language:

--- a/.claude/commands/rumiator-create-bug.md
+++ b/.claude/commands/rumiator-create-bug.md
@@ -16,38 +16,39 @@ Prerequisites:
 
 ## Steps
 
-1. Parse optional related-task-id from command
-2. If related-task-id provided:
-   - Validate it exists in .rumiator/tasks/
+1. Read .rumiator/config.yml to get current iteration number
+2. Parse optional related-task-id from command
+3. If related-task-id provided:
+   - Validate it exists in docs/iterations/iteration-XX/tasks/ (where XX is current iteration)
    - Read the task to understand context
    - Extract feature name for categorization
-3. If no related-task-id, ask user:
+4. If no related-task-id, ask user:
    - Which feature is affected? (list existing features from docs/features/)
    - Or is this a new/general bug?
-4. Ask user for bug details:
+5. Ask user for bug details:
    - **Title**: Brief description of the bug
    - **Severity**: low | medium | high | critical
    - **Steps to reproduce**: How to trigger the bug
    - **Expected behavior**: What should happen
    - **Actual behavior**: What actually happens
    - **Root cause** (if known): Optional, can be determined during analysis
-5. Determine next TASK-ID:
-   - Scan .rumiator/tasks/ for highest existing ID
+6. Determine next TASK-ID:
+   - Scan docs/iterations/iteration-XX/tasks/ (where XX is current iteration) for highest existing ID
    - Increment to get next ID (TASK-XXX)
-6. Determine iteration placement based on severity:
+7. Determine iteration placement based on severity:
    - **Critical/High**: Add to current iteration with high priority
    - **Medium**: Add to current iteration with medium priority
    - **Low**: Add to backlog (current iteration + 1) with low priority
-7. Create .rumiator/tasks/TASK-XXX.yml:
+8. Create docs/iterations/iteration-XX/tasks/TASK-XXX.yml (where XX is the target iteration):
    - type: bug
    - Set all bug_info fields
    - Set status: "draft"
    - Set priority based on severity
    - Add related_tasks if applicable
-8. Create bug analysis directory:
+9. Create bug analysis directory:
    - docs/features/[feature]/bugs/ (if doesn't exist)
    - Create placeholder: docs/features/[feature]/bugs/BUG-XXX-analysis.md
-9. If related to existing TASK(s):
+10. If related to existing TASK(s):
    - Read each related task YAML
    - Add this bug ID to their related_bugs array
    - Add note about the bug

--- a/.claude/commands/rumiator-create-tasks.md
+++ b/.claude/commands/rumiator-create-tasks.md
@@ -18,8 +18,8 @@ Prerequisites:
 4. Launch the functional-analyst agent in "Task Creation Mode":
    - Identify all features for the current iteration
    - For each feature:
-     * Determine next task ID (check existing tasks in .rumiator/tasks/)
-     * Create .rumiator/tasks/TASK-XXX.yml with:
+     * Determine next task ID (check existing tasks in docs/iterations/iteration-XX/tasks/)
+     * Create docs/iterations/iteration-XX/tasks/TASK-XXX.yml with:
        - Basic metadata (id, type, title, feature, priority, iteration, dates)
        - **summary**: 3-5 line description of what the task accomplishes
        - **user_stories**: List of user stories in format "As a [role], I want to [action], so that [benefit]"

--- a/.claude/commands/rumiator-develop-next.md
+++ b/.claude/commands/rumiator-develop-next.md
@@ -12,8 +12,9 @@ Prerequisites:
 
 ## Steps
 
-1. Scan .rumiator/tasks/ for all tasks with status "ready-for-development"
-2. If no tasks are ready:
+1. Read .rumiator/config.yml to get current iteration number
+2. Scan docs/iterations/iteration-XX/tasks/ (where XX is current iteration) for all tasks with status "ready-for-development"
+3. If no tasks are ready:
    - Check if there are tasks in earlier stages
    - Display status breakdown (X pending analysis, Y in progress, Z done)
    - Suggest appropriate command:

--- a/.claude/commands/rumiator-init.md
+++ b/.claude/commands/rumiator-init.md
@@ -25,7 +25,7 @@ Initialize a Rumiator project with the complete directory structure and configur
 
 3. Check if .rumiator/ already exists. If it does, ask user if they want to reinitialize.
 4. Create the complete directory structure:
-    - .rumiator/tasks/
+    - .rumiator/
     - repositories/ (if it doesn't exist yet - for new projects)
     - docs/product/
     - docs/adr/
@@ -38,7 +38,9 @@ Initialize a Rumiator project with the complete directory structure and configur
     - Brief description
     - Preferred tech stack (if known)
 7. Update .rumiator/config.yml with the provided information and current date
-8. Create initial iteration plan file: docs/iterations/iteration-01/plan.md with template:
+8. Create initial directories and files:
+   - Create docs/iterations/iteration-01/tasks/ directory for task files
+   - Create docs/iterations/iteration-01/plan.md with template:
    ```markdown
    # Iteration 01 Plan
 

--- a/.claude/commands/rumiator-propagate-architecture-change.md
+++ b/.claude/commands/rumiator-propagate-architecture-change.md
@@ -44,7 +44,8 @@ This command handles the cascading updates needed when an architectural decision
 
    **In Task YAMLs:**
    ```
-   Search: .rumiator/tasks/*.yml
+   Read .rumiator/config.yml to get current iteration
+   Search: docs/iterations/iteration-XX/tasks/*.yml (where XX is current iteration)
    Pattern: related_adrs containing old ADR-YYY
    Also search: tasks with related features
    ```
@@ -210,8 +211,9 @@ This command handles the cascading updates needed when an architectural decision
     **Creating Architecture Review Tasks:**
     ```
     For each completed task needing review:
-    1. Get next TASK-ID
-    2. Create new TASK-XXX.yml:
+    1. Read .rumiator/config.yml to get current iteration
+    2. Get next TASK-ID
+    3. Create new docs/iterations/iteration-XX/tasks/TASK-XXX.yml (where XX is current iteration):
        - type: architecture-review
        - title: "Review [original-task] against ADR-XXX"
        - architecture_review:
@@ -221,7 +223,7 @@ This command handles the cascading updates needed when an architectural decision
        - status: "pending-technical-analysis"
        - priority: based on impact (high/medium/low)
        - iteration: current or next
-    3. Add reference in original task's related_bugs/notes
+    4. Add reference in original task's related_bugs/notes
     ```
 
     **Pausing In-Progress Tasks:**

--- a/.claude/commands/rumiator-status.md
+++ b/.claude/commands/rumiator-status.md
@@ -9,8 +9,8 @@ Display a comprehensive status dashboard of the current project and its tasks.
 
 ## Steps
 
-1. Read .rumiator/config.yml to get project metadata
-2. Scan all tasks in .rumiator/tasks/ directory
+1. Read .rumiator/config.yml to get project metadata and current iteration number
+2. Scan all tasks in docs/iterations/iteration-XX/tasks/ directory (where XX is the current iteration)
 3. Categorize tasks by type:
    - Features (type: feature or missing type field)
    - Bugs (type: bug)

--- a/.claude/commands/rumiator-triage-bugs.md
+++ b/.claude/commands/rumiator-triage-bugs.md
@@ -17,7 +17,7 @@ Prerequisites:
 ## Steps
 
 1. Read .rumiator/config.yml to get current iteration number
-2. Scan .rumiator/tasks/ for all TASK-XXX.yml files with type: bug
+2. Scan docs/iterations/iteration-XX/tasks/ (where XX is current iteration) for all TASK-XXX.yml files with type: bug
 3. Filter bugs based on command flag:
    - Default: Only bugs for current iteration
    - --all: All bugs regardless of iteration

--- a/.claude/commands/rumiator-update-plan.md
+++ b/.claude/commands/rumiator-update-plan.md
@@ -27,7 +27,8 @@ Prerequisites:
    - Maintain consistency across the document
 5. Display a summary of the changes made
 6. Check if there are existing tasks that might be affected:
-   - Scan .rumiator/tasks/ directory
+   - Read .rumiator/config.yml to get current iteration number
+   - Scan docs/iterations/iteration-XX/tasks/ directory (where XX is current iteration)
    - Warn user if changes might impact existing tasks
    - Suggest running /rumiator-create-tasks to add new tasks if scope increased
 

--- a/RUMIATOR-GUIDE.md
+++ b/RUMIATOR-GUIDE.md
@@ -138,7 +138,7 @@ The PM will generate a plan with iterations like:
 The functional analyst:
 - Reads the product plan
 - Identifies features for current iteration
-- Creates task files (.rumiator/tasks/TASK-XXX.yml) with:
+- Creates task files (docs/iterations/iteration-XX/tasks/TASK-XXX.yml) with:
   - **Summary**: 3-5 line description of what the task accomplishes
   - **User Stories**: User-focused stories describing the feature
   - **Acceptance Criteria**: Specific, testable criteria

--- a/RUMIATOR_CHANGELOG.md
+++ b/RUMIATOR_CHANGELOG.md
@@ -13,6 +13,60 @@ Each version should include:
 - **Changes**: Categorized as Added, Changed, Deprecated, Removed, Fixed, Security
 - **Migration instructions**: What users need to do to update their projects
 
+## [2.2.0] - 2025-11-06
+
+### Summary
+Fixed task file structure to organize tasks by iteration, preventing file conflicts and improving command performance as projects scale.
+
+### Fixed
+- Bug #9: Task files now reside in `docs/iterations/iteration-XX/tasks/` instead of `.rumiator/tasks/`
+- Commands no longer slow down as more tasks are created across iterations
+- Task files no longer conflict when transitioning between iterations
+
+### Changed
+- All commands updated to read/write tasks from iteration-specific directories
+- All agents updated to use iteration-specific task paths
+- `/rumiator-init` now creates `docs/iterations/iteration-01/tasks/` directory
+
+### Migration Instructions
+- **Type**: `automatic` for new projects, `manual` for existing projects
+- **Actions**:
+```yaml
+migrations:
+  - type: "message"
+    message: |
+      📁 IMPORTANT: Task file structure has changed
+
+      **What changed:**
+      - Task files now reside in `docs/iterations/iteration-XX/tasks/` instead of `.rumiator/tasks/`
+      - This ensures tasks are organized by iteration
+      - Commands only read tasks from current iteration (faster, fewer tokens)
+
+      **For NEW projects:**
+      - No action needed - `/rumiator-init` creates the correct structure
+
+      **For EXISTING projects with tasks:**
+      1. Read `.rumiator/config.yml` to get current iteration number
+      2. Create directory: `docs/iterations/iteration-XX/tasks/` (where XX is current iteration)
+      3. Move task files:
+         ```bash
+         mkdir -p docs/iterations/iteration-01/tasks
+         mv .rumiator/tasks/*.yml docs/iterations/iteration-01/tasks/
+         ```
+      4. If you have multiple iterations:
+         - Separate tasks by iteration number
+         - Move each TASK-XXX.yml to its corresponding iteration directory
+
+      **Benefits:**
+      - Commands run faster (only scan current iteration's tasks)
+      - No file conflicts between iterations
+      - Clear organization: each iteration's tasks are self-contained
+      - Lower token usage as project scales
+```
+- **Description**: Reorganizes task files by iteration to improve performance and prevent conflicts.
+
+---
+
 ## [2.1.0] - 2025-11-01
 
 ### Summary


### PR DESCRIPTION
This commit resolves issue #9 by changing the task file structure from a single shared directory to iteration-specific directories.

Changes:
- Tasks now reside in docs/iterations/iteration-XX/tasks/ instead of .rumiator/tasks/
- All commands updated to read current iteration from config and use correct directory
- All agents updated to use iteration-specific task paths
- rumiator-init creates tasks directory within iteration structure
- Updated documentation to reflect new structure
- Added version 2.2.0 to changelog with migration instructions

Benefits:
- No file conflicts when transitioning between iterations
- Commands run faster (only scan current iteration)
- Lower token usage as project scales
- Clear organization with tasks grouped by iteration

Breaking change: Existing projects need to manually move task files to iteration-specific directories. See RUMIATOR_CHANGELOG.md for migration instructions.

Fixes #9