### PR TITLE
Resolve Issue #13

### DIFF
--- a/.claude/commands/rumiator-update.md
+++ b/.claude/commands/rumiator-update.md
@@ -8,9 +8,11 @@ Update the current Rumiator project to the latest version from the official repo
 
 ## Overview
 This command updates the project to the latest Rumiator version by:
-1. Cloning/updating the official repository
+1. Cloning/updating the official repository (using the latest published release)
 2. Comparing versions
 3. Applying migrations from RUMIATOR_CHANGELOG.md
+
+**Note:** This command uses the latest published GitHub Release instead of the master branch to ensure stability. The release is automatically created when a new version is documented in RUMIATOR_CHANGELOG.md.
 
 ## Steps
 
@@ -24,13 +26,43 @@ b. Read current `rumiator_version` from `.rumiator/config.yml`
 
 ### 2. Clone/Update Official Repository
 
-a. Check if `repositories/claude-rumiator/` exists
-   - If not, clone: `git clone https://github.com/alextremp/claude-rumiator.git repositories/claude-rumiator`
-   - If exists, update: `cd repositories/claude-rumiator && git pull origin master`
+a. Get latest release version from GitHub:
+   - Use GitHub CLI: `gh api repos/alextremp/claude-rumiator/releases/latest --jq '.tag_name'`
+   - Extract tag name (e.g., "v2.3.0")
+   - If API call fails (no `gh` CLI, network error, no releases), set fallback to use `master` branch and display warning to user
+   - Store the tag name for checkout
 
-b. Handle git errors gracefully:
+b. Check if `repositories/claude-rumiator/` exists:
+   - If not, clone repository:
+     ```bash
+     git clone https://github.com/alextremp/claude-rumiator.git repositories/claude-rumiator
+     ```
+   - Then checkout the latest release tag:
+     ```bash
+     cd repositories/claude-rumiator && git fetch --tags && git checkout <latest-release-tag>
+     ```
+   - If using fallback (no releases), checkout master:
+     ```bash
+     cd repositories/claude-rumiator && git checkout master && git pull origin master
+     ```
+
+   - If exists, update to latest release:
+     ```bash
+     cd repositories/claude-rumiator && git fetch --tags && git checkout <latest-release-tag>
+     ```
+   - If using fallback (no releases), update master:
+     ```bash
+     cd repositories/claude-rumiator && git checkout master && git pull origin master
+     ```
+
+c. Handle git errors gracefully:
    - If repository has local changes, inform user to clean it or remove the directory
    - If network error, inform user to check connection
+   - If checkout fails, try to fallback to master branch with warning
+
+d. Display information to user:
+   - If using release: "Using official release version: vX.Y.Z"
+   - If using fallback: "⚠️ Warning: Could not fetch latest release, using master branch as fallback. This may include unreleased changes."
 
 ### 3. Compare Versions
 
@@ -224,6 +256,7 @@ For file overwrites:
 ```
 🔄 Actualizando Rumiator...
 
+✓ Usando release oficial: v1.2.0
 ✓ Repositorio oficial actualizado
   Versión actual: 1.0.0
   Versión disponible: 1.2.0
@@ -249,6 +282,7 @@ Próximos pasos:
 ```
 🔄 Updating Rumiator...
 
+✓ Using official release: v1.2.0
 ✓ Official repository updated
   Current version: 1.0.0
   Available version: 1.2.0

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,192 @@
+name: Auto Release
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'RUMIATOR_CHANGELOG.md'
+
+permissions:
+  contents: write
+
+jobs:
+  auto-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from changelog
+        id: version
+        run: |
+          # Extract the first version entry from RUMIATOR_CHANGELOG.md
+          # Format: ## [X.Y.Z] - YYYY-MM-DD
+          VERSION=$(grep -m 1 -oP '##\s+\[\K[0-9]+\.[0-9]+\.[0-9]+(?=\])' RUMIATOR_CHANGELOG.md)
+
+          if [ -z "$VERSION" ]; then
+            echo "❌ No version found in RUMIATOR_CHANGELOG.md"
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "✅ Found version in changelog: $VERSION"
+
+          # Extract the changelog content for this version (until next version or end of changelog)
+          # We'll extract from ## [X.Y.Z] to the next ## [ or end of file
+          CHANGELOG_CONTENT=$(awk '/^## \['$VERSION'\]/{flag=1; next} /^## \[/{flag=0} flag' RUMIATOR_CHANGELOG.md)
+
+          # Create a summary (first 500 chars of changelog)
+          SUMMARY=$(echo "$CHANGELOG_CONTENT" | head -c 500)
+          if [ ${#CHANGELOG_CONTENT} -gt 500 ]; then
+            SUMMARY="${SUMMARY}..."
+          fi
+
+          # Save to file to preserve multiline
+          echo "$SUMMARY" > /tmp/summary.txt
+
+          echo "✅ Extracted changelog summary"
+
+      - name: Get latest release
+        id: latest_release
+        run: |
+          # Get the latest release version from GitHub
+          LATEST_RELEASE=$(gh api repos/${{ github.repository }}/releases/latest --jq '.tag_name' 2>/dev/null || echo "")
+
+          if [ -z "$LATEST_RELEASE" ]; then
+            echo "⚠️ No previous releases found"
+            echo "latest_version=0.0.0" >> $GITHUB_OUTPUT
+            echo "previous_tag=" >> $GITHUB_OUTPUT
+          else
+            # Remove 'v' prefix if present
+            LATEST_VERSION=${LATEST_RELEASE#v}
+            echo "latest_version=$LATEST_VERSION" >> $GITHUB_OUTPUT
+            echo "previous_tag=$LATEST_RELEASE" >> $GITHUB_OUTPUT
+            echo "✅ Latest release: $LATEST_VERSION"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compare versions
+        id: compare
+        run: |
+          NEW_VERSION="${{ steps.version.outputs.version }}"
+          LATEST_VERSION="${{ steps.latest_release.outputs.latest_version }}"
+
+          echo "Comparing versions: $NEW_VERSION vs $LATEST_VERSION"
+
+          # Simple semver comparison
+          # Split versions into arrays
+          IFS='.' read -ra NEW <<< "$NEW_VERSION"
+          IFS='.' read -ra LATEST <<< "$LATEST_VERSION"
+
+          SHOULD_RELEASE=false
+
+          # Compare major
+          if [ "${NEW[0]}" -gt "${LATEST[0]}" ]; then
+            SHOULD_RELEASE=true
+          elif [ "${NEW[0]}" -eq "${LATEST[0]}" ]; then
+            # Compare minor
+            if [ "${NEW[1]}" -gt "${LATEST[1]}" ]; then
+              SHOULD_RELEASE=true
+            elif [ "${NEW[1]}" -eq "${LATEST[1]}" ]; then
+              # Compare patch
+              if [ "${NEW[2]}" -gt "${LATEST[2]}" ]; then
+                SHOULD_RELEASE=true
+              fi
+            fi
+          fi
+
+          echo "should_release=$SHOULD_RELEASE" >> $GITHUB_OUTPUT
+
+          if [ "$SHOULD_RELEASE" = true ]; then
+            echo "✅ New version detected: $NEW_VERSION > $LATEST_VERSION"
+          else
+            echo "ℹ️ Version $NEW_VERSION is not greater than $LATEST_VERSION - skipping release"
+          fi
+
+      - name: Check and update config.yml.template
+        id: update_config
+        if: steps.compare.outputs.should_release == 'true'
+        run: |
+          NEW_VERSION="${{ steps.version.outputs.version }}"
+          CONFIG_FILE=".rumiator/config.yml.template"
+
+          # Read current rumiator_version from config
+          CURRENT_CONFIG_VERSION=$(grep -oP 'rumiator_version:\s*"\K[^"]+' "$CONFIG_FILE" || echo "")
+
+          echo "Config version: $CURRENT_CONFIG_VERSION"
+          echo "Changelog version: $NEW_VERSION"
+
+          if [ "$CURRENT_CONFIG_VERSION" != "$NEW_VERSION" ]; then
+            echo "⚠️ Version mismatch detected - updating config.yml.template"
+
+            # Update the version in config.yml.template
+            sed -i "s/rumiator_version: \".*\"/rumiator_version: \"$NEW_VERSION\"/" "$CONFIG_FILE"
+
+            # Configure git
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+
+            # Commit and push
+            git add "$CONFIG_FILE"
+            git commit -m "chore: update rumiator_version to $NEW_VERSION"
+            git push
+
+            echo "config_updated=true" >> $GITHUB_OUTPUT
+            echo "✅ Config updated and committed"
+          else
+            echo "config_updated=false" >> $GITHUB_OUTPUT
+            echo "✅ Config already up to date"
+          fi
+
+      - name: Create GitHub Release
+        if: steps.compare.outputs.should_release == 'true'
+        run: |
+          NEW_VERSION="${{ steps.version.outputs.version }}"
+          PREVIOUS_TAG="${{ steps.latest_release.outputs.previous_tag }}"
+
+          # Read the summary
+          SUMMARY=$(cat /tmp/summary.txt)
+
+          # Create comparison link
+          if [ -n "$PREVIOUS_TAG" ]; then
+            PREV_VERSION=${PREVIOUS_TAG#v}
+            COMPARE_LINK="**Full Changelog:** https://github.com/${{ github.repository }}/compare/${PREV_VERSION}...${NEW_VERSION}"
+          else
+            COMPARE_LINK="**First Release**"
+          fi
+
+          # Create release body
+          RELEASE_BODY=$(cat <<EOF
+          $SUMMARY
+
+          ---
+
+          $COMPARE_LINK
+          EOF
+          )
+
+          # Create the release
+          echo "$RELEASE_BODY" | gh release create "v${NEW_VERSION}" \
+            --title "Version ${NEW_VERSION}" \
+            --notes-file - \
+            --latest
+
+          echo "✅ Release v${NEW_VERSION} created successfully!"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Summary
+        if: steps.compare.outputs.should_release == 'true'
+        run: |
+          echo "## 🚀 Release Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version:** ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Config Updated:** ${{ steps.update_config.outputs.config_updated }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Release Created:** ✅" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "[View Release](https://github.com/${{ github.repository }}/releases/tag/v${{ steps.version.outputs.version }})" >> $GITHUB_STEP_SUMMARY

--- a/.rumiator/config.yml.template
+++ b/.rumiator/config.yml.template
@@ -1,6 +1,6 @@
 # Rumiator Project Configuration
 language: "es-ES"
-rumiator_version: "2.3.0"
+rumiator_version: "2.4.0"
 
 project:
   name: ""

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Rumiator helps you build software projects systematically by combining specializ
 
 **⚡ New**: Business requirements now integrated into task creation - faster workflow!
 **🎨 New**: Customize commands and agents to fit your workflow - without losing changes on updates!
+**🚀 New**: Automatic release system - updates use stable releases instead of master branch!
 
 ## Features
 
@@ -42,6 +43,8 @@ Rumiator helps you build software projects systematically by combining specializ
 - ✅ **Bug tracking & management** - Track bugs alongside features
 - ✅ **Architecture evolution** - Review and update architectural decisions
 - ✅ **Customizable workflows** - Override commands and agents to match your team's needs
+- ✅ **Automatic releases** - GitHub Actions automatically creates releases when changelog is updated
+- ✅ **Stable updates** - `/rumiator-update` uses published releases instead of master branch
 - ✅ **You're in control** - Agents ask before important decisions
 
 ## Architecture
@@ -188,6 +191,32 @@ Topics covered:
 - Best practices
 - Customization guide
 - FAQ
+
+## Release Management
+
+Rumiator uses an automated release system to ensure stable updates:
+
+### Automatic Releases
+
+When a new version is documented in `RUMIATOR_CHANGELOG.md`, GitHub Actions automatically:
+1. ✅ Detects the new version (format: `[X.Y.Z] - YYYY-MM-DD`)
+2. ✅ Compares with the latest published release
+3. ✅ Ensures `config.yml.template` has matching `rumiator_version`
+4. ✅ Creates a GitHub Release with changelog summary and comparison link
+
+### Stable Updates
+
+When you run `/rumiator-update`, it:
+- ✅ Uses the latest **published release** (not master branch)
+- ✅ Ensures you get tested, stable versions
+- ✅ Falls back to master only if releases are unavailable (with warning)
+
+### Benefits
+
+- **Stability** - Updates use verified releases
+- **Traceability** - Each release has clear changelog
+- **Consistency** - Version always matches between changelog and config
+- **Automation** - No manual release creation needed
 
 ## Requirements
 

--- a/RUMIATOR-GUIDE.md
+++ b/RUMIATOR-GUIDE.md
@@ -834,6 +834,69 @@ Edit `.rumiator/templates/*.md` to:
 - Add custom sections
 - Adjust formatting
 
+## 🚀 Release Management & Updates
+
+Rumiator includes an automated release system to ensure stable and consistent updates across all installations.
+
+### How Releases Work
+
+1. **Automatic Release Creation**
+   - When `RUMIATOR_CHANGELOG.md` is updated with a new version (format: `[X.Y.Z] - YYYY-MM-DD`)
+   - GitHub Actions workflow automatically detects the version change
+   - The workflow verifies `config.yml.template` has matching `rumiator_version`
+   - If versions don't match, it automatically updates and commits the config
+   - Creates a GitHub Release with:
+     - Tag: `vX.Y.Z`
+     - Title: `Version X.Y.Z`
+     - Body: Summary of changes + comparison link (e.g., `2.3.0...2.4.0`)
+
+2. **Stable Updates with `/rumiator-update`**
+   - Fetches the latest **published GitHub Release** (not master branch)
+   - Ensures you receive tested, stable versions
+   - Falls back to master branch only if:
+     - GitHub API is unavailable
+     - No releases have been published yet
+     - Displays warning when using fallback mode
+
+### Benefits
+
+- ✅ **Consistency** - Version in changelog always matches config
+- ✅ **Stability** - Updates use verified releases, not work-in-progress code
+- ✅ **Traceability** - Each release has clear changelog and comparison
+- ✅ **Automation** - No manual release creation needed
+- ✅ **Transparency** - Full change history with links to diffs
+
+### For Contributors
+
+When adding new features to Rumiator:
+
+1. Make your changes in a feature branch
+2. Update `RUMIATOR_CHANGELOG.md` with new version entry:
+   ```markdown
+   ## [X.Y.Z] - YYYY-MM-DD
+
+   ### Summary
+   Brief description of changes
+
+   ### Added/Changed/Fixed
+   - Detailed changes...
+
+   ### Migration Instructions
+   - Type: automatic/manual/none
+   - Actions: ...
+   ```
+3. Commit and push to master
+4. GitHub Actions automatically:
+   - Updates `config.yml.template` if needed
+   - Creates the release with summary and comparison link
+
+### Version Numbering
+
+Rumiator follows [Semantic Versioning](https://semver.org/):
+- **MAJOR** (X.0.0) - Breaking changes, manual migration required
+- **MINOR** (0.X.0) - New features, backwards compatible
+- **PATCH** (0.0.X) - Bug fixes, backwards compatible
+
 ## ❓ FAQ
 
 ### When should I use Rumiator?

--- a/RUMIATOR_CHANGELOG.md
+++ b/RUMIATOR_CHANGELOG.md
@@ -13,6 +13,71 @@ Each version should include:
 - **Changes**: Categorized as Added, Changed, Deprecated, Removed, Fixed, Security
 - **Migration instructions**: What users need to do to update their projects
 
+## [2.4.0] - 2025-11-07
+
+### Summary
+Improved release workflow with automatic GitHub Release creation and stable update system. When changelog is updated with a new version, GitHub Actions automatically ensures config consistency and creates releases. The `/rumiator-update` command now uses published releases instead of master branch for more stable updates.
+
+### Added
+- Feature #13: Automated release management system
+- New GitHub Action: `.github/workflows/auto-release.yml` - Automatically creates releases when changelog is updated
+- Release automation: Detects new versions in changelog, verifies config.yml.template consistency, creates GitHub Releases
+- Version consistency: Automatically commits config.yml.template updates when version mismatch detected
+- Release format: Includes changelog summary and comparison link (e.g., `https://github.com/alextremp/claude-rumiator/compare/2.3.0...2.4.0`)
+
+### Changed
+- Updated command: `/rumiator-update` - Now fetches and uses latest published GitHub Release instead of master branch
+- Updated command: `/rumiator-update` - Added fallback to master branch with warning if releases unavailable
+- Updated README.md: Added "Release Management" section documenting the new system
+- Updated RUMIATOR-GUIDE.md: Added "Release Management & Updates" section with detailed documentation
+
+### Migration Instructions
+- **Type**: `automatic`
+- **Actions**:
+```yaml
+migrations:
+  - type: "add_file"
+    description: "Add GitHub Actions workflow for auto-release"
+    source: ".github/workflows/auto-release.yml"
+    target: ".github/workflows/auto-release.yml"
+    optional: false
+
+  - type: "message"
+    message: |
+      🚀 NEW FEATURE: Automated Release System
+
+      **What's new:**
+      - Releases are now created automatically when RUMIATOR_CHANGELOG.md is updated
+      - GitHub Actions workflow ensures version consistency between changelog and config
+      - `/rumiator-update` now uses stable published releases instead of master branch
+      - Each release includes a summary and comparison link
+
+      **How it works:**
+      1. When you add a new version entry to RUMIATOR_CHANGELOG.md (format: [X.Y.Z] - YYYY-MM-DD)
+      2. Push to master branch
+      3. GitHub Actions automatically:
+         - Detects the new version
+         - Verifies config.yml.template has matching rumiator_version
+         - Updates config if needed (automatic commit)
+         - Creates a GitHub Release with changelog summary and comparison link
+
+      **For updates:**
+      - `/rumiator-update` now downloads from latest published release
+      - More stable: you get tested versions, not work-in-progress code
+      - Automatic fallback to master if releases unavailable (with warning)
+
+      **Benefits:**
+      - ✅ Version consistency guaranteed
+      - ✅ Stable, tested updates
+      - ✅ Clear traceability with comparison links
+      - ✅ No manual release creation needed
+
+      **No action needed** - The new workflow applies automatically on next update!
+```
+- **Description**: Adds automated release management system that creates GitHub Releases when changelog is updated and ensures `/rumiator-update` uses stable published releases.
+
+---
+
 ## [2.3.0] - 2025-11-06
 
 ### Summary


### PR DESCRIPTION
- Add GitHub Action for automatic release creation
- Auto-create releases when RUMIATOR_CHANGELOG.md is updated
- Auto-verify and update config.yml.template version consistency
- Update /rumiator-update to use published releases instead of master
- Add fallback to master with warning if releases unavailable
- Include changelog summary and comparison links in releases
- Update documentation (README, RUMIATOR-GUIDE)
- Bump version to 2.4.0

Benefits:
- Version consistency guaranteed
- Stable, tested updates via published releases
- Clear traceability with comparison links
- No manual release creation needed

Fixes #13 